### PR TITLE
Lint also needs to set the default JPath for mixins that vendor libraries.

### DIFF
--- a/cmd/mixtool/lint.go
+++ b/cmd/mixtool/lint.go
@@ -59,8 +59,11 @@ func lintCommand() cli.Command {
 }
 
 func lintAction(c *cli.Context) error {
+	jPath := c.StringSlice("jpath")
+	jPath = availableVendor(jPath)
+
 	options := mixer.LintOptions{
-		JPaths:     c.StringSlice("jpath"),
+		JPaths:     jPath,
 		Grafana:    c.BoolT("grafana"),
 		Prometheus: c.BoolT("prometheus"),
 	}


### PR DESCRIPTION
Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>