### PR TITLE
Make lint subcommand exit with non-zero error code when errors are found.

### DIFF
--- a/pkg/mixer/eval.go
+++ b/pkg/mixer/eval.go
@@ -21,16 +21,37 @@ import (
 )
 
 func evaluatePrometheusAlerts(vm *jsonnet.VM, filename string) (string, error) {
-	snippet := fmt.Sprintf("(import '%s').prometheusAlerts", filename)
+	snippet := fmt.Sprintf(`
+local mixin = (import %q);
+
+if std.objectHas(mixin, "prometheusAlerts")
+then mixin.prometheusAlerts
+else {}
+`, filename)
+
 	return vm.EvaluateSnippet("", snippet)
 }
 
 func evaluatePrometheusRules(vm *jsonnet.VM, filename string) (string, error) {
-	snippet := fmt.Sprintf("(import '%s').prometheusRules", filename)
+	snippet := fmt.Sprintf(`
+local mixin = (import %q);
+
+if std.objectHas(mixin, "prometheusRules")
+then mixin.prometheusRules
+else {}
+`, filename)
+
 	return vm.EvaluateSnippet("", snippet)
 }
 
 func evaluateGrafanaDashboards(vm *jsonnet.VM, filename string) (string, error) {
-	snippet := fmt.Sprintf("(import '%s').grafanaDashboards", filename)
+	snippet := fmt.Sprintf(`
+local mixin = (import %q);
+
+if std.objectHas(mixin, "grafanaDashboards")
+then mixin.grafanaDashboards
+else {}
+`, filename)
+
 	return vm.EvaluateSnippet("", snippet)
 }


### PR DESCRIPTION
So you can use it in a Makefile, and have it fail correctly.

I tried using a channel to pass errors instead of returning []error.  Not sure how I feel about it now.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>