### PR TITLE
Skip the install test as the dependancy on external mixins makes it super unreliable.

### DIFF
--- a/cmd/mixtool/install_test.go
+++ b/cmd/mixtool/install_test.go
@@ -28,6 +28,8 @@ import (
 // Try to install every mixin from the mixin repository
 // verify that each package generated has the yaml files
 func TestInstallMixin(t *testing.T) {
+	t.Skip("Test is unreliable as it depends on external mixins.")
+
 	body, err := queryWebsite(defaultWebsite)
 	if err != nil {
 		t.Errorf("failed to query website %v", err)


### PR DESCRIPTION
Its failing right now as many mixins have moved: https://app.circleci.com/pipelines/github/monitoring-mixins/mixtool/60/workflows/f7276347-71f3-4b41-b02a-eb0663ea8f1b/jobs/171

We shouldn't depend on external resources like this in unit tests.

Signed-off-by: Tom Wilkie <tom@grafana.com>