### PR TITLE
Update grafana/dashboard-linter.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gobuffalo/packr/v2 v2.8.1
 	github.com/google/go-jsonnet v0.17.0
 	github.com/google/uuid v1.3.0 // indirect
-	github.com/grafana/dashboard-linter v0.0.0-20211118105528-45a9c2cafebe
+	github.com/grafana/dashboard-linter v0.0.0-20211119180650-86fa94beade2
 	github.com/grafana/tanka v0.17.2
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/jsonnet-bundler/jsonnet-bundler v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -762,8 +762,8 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/grafana/dashboard-linter v0.0.0-20211118105528-45a9c2cafebe h1:yQxf26GE25KGCC5p31Vk8IiAOdHX8Tw490OGyQP79eA=
-github.com/grafana/dashboard-linter v0.0.0-20211118105528-45a9c2cafebe/go.mod h1://CkibdjQDn6tp3o6QEso8n75KsHI/14BnRRDbx2hN0=
+github.com/grafana/dashboard-linter v0.0.0-20211119180650-86fa94beade2 h1:2McaKRcok0qkirkQdGrb2wCW5S7T99UOc40ogqRKLfw=
+github.com/grafana/dashboard-linter v0.0.0-20211119180650-86fa94beade2/go.mod h1://CkibdjQDn6tp3o6QEso8n75KsHI/14BnRRDbx2hN0=
 github.com/grafana/tanka v0.17.2 h1:Kb1bPzYbsBU1h13ZcQSQMjmccNX6sTDJzPjNQXhS92I=
 github.com/grafana/tanka v0.17.2/go.mod h1:ElgnBorTuXd3B4XTKug0okH42NMxy20iqiSBwRh6Fm8=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=


### PR DESCRIPTION
Splits the rule for linting PromQL queries in two, so we can ignore half the check, and improves the parsing of datasource types.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>