### PR TITLE
Remove dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "gomod"
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10


### PR DESCRIPTION
I've enabled renovatebot as it allows us to track non-semantically-versioned repos (such as dashboard-linter).

Lets just treat this as an experiment for now.  I think I can get renovatebot to properly track prometheus too...

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>