### PR TITLE
Enforce alerting guidelines by linter

### DIFF
--- a/pkg/mixer/lint.go
+++ b/pkg/mixer/lint.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"path"
+	"regexp"
 
 	"github.com/fatih/color"
 	"github.com/google/go-jsonnet"
@@ -72,22 +73,65 @@ func lintPrometheus(filename string, vm *jsonnet.VM, errsOut chan<- error) {
 		errsOut <- err
 		return
 	}
-
-	_, errs := rulefmt.Parse([]byte(j))
+	groups, errs := rulefmt.Parse([]byte(j))
 	for _, err := range errs {
 		errsOut <- err
 	}
 
-	j, err = evaluatePrometheusRules(vm, filename)
+	for _, g := range groups.Groups {
+		for _, r := range g.Rules {
+			errs = lintPrometheusAlertsGuidelines(&r)
+			for _, err := range errs {
+				errsOut <- err
+			}
+		}
+	}
+
+	_, err = evaluatePrometheusRules(vm, filename)
 	if err != nil {
 		errsOut <- err
 		return
 	}
 
-	_, errs = rulefmt.Parse([]byte(j))
-	for _, err := range errs {
-		errsOut <- err
+}
+
+var camelCaseRegexp = regexp.MustCompile(`^([A-Z][a-z0-9]+)+$`)
+var goTemplateRegexp = regexp.MustCompile(`\{\{.+}\}`)
+var sentenceRegexp = regexp.MustCompile(`^[A-Z].+\.$`)
+
+// Enforces alerting guidelines.
+// https://monitoring.mixins.dev/#guidelines-for-alert-names-labels-and-annotations
+func lintPrometheusAlertsGuidelines(rule *rulefmt.RuleNode) (errs []error) {
+
+	if !camelCaseRegexp.MatchString(rule.Alert.Value) {
+		errs = append(errs, fmt.Errorf("[alert-name-camelcase] Alert '%s' name is not in camel case", rule.Alert.Value))
 	}
+
+	if rule.Labels["severity"] != "warning" && rule.Labels["severity"] != "critical" && rule.Labels["severity"] != "info" {
+		errs = append(errs, fmt.Errorf("[alert-severity-rule] Alert '%s' severify must be 'warning', 'critical' or 'info', is currently '%s'", rule.Alert.Value, rule.Labels["severity"]))
+	}
+
+	if _, ok := rule.Annotations["description"]; !ok {
+		errs = append(errs, fmt.Errorf("[alert-description-missing-rule] Alert '%s' must have annotation 'description'", rule.Alert.Value))
+	} else {
+
+		if !goTemplateRegexp.MatchString(rule.Annotations["description"]) {
+			errs = append(errs, fmt.Errorf("[alert-description-templating] Alert %s annotation 'description' must use templates, is currently '%s'", rule.Alert.Value, rule.Annotations["description"]))
+		}
+	}
+
+	if _, ok := rule.Annotations["summary"]; !ok {
+		errs = append(errs, fmt.Errorf("[alert-summary-missing-rule] Alert '%s' must have annotation 'summary'", rule.Alert.Value))
+	} else {
+
+		if goTemplateRegexp.MatchString(rule.Annotations["summary"]) {
+			errs = append(errs, fmt.Errorf("[alert-summary-templating] Alert %s annotation 'summary' must not use templates", rule.Alert.Value))
+		}
+		if !sentenceRegexp.MatchString(rule.Annotations["summary"]) {
+			errs = append(errs, fmt.Errorf("[alert-summary-style] Alert %s annotation 'summary' must start with capital letter and end with period, is currently '%s'", rule.Alert.Value, rule.Annotations["summary"]))
+		}
+	}
+	return errs
 }
 
 func lintGrafanaDashboards(filename string, vm *jsonnet.VM, errsOut chan<- error) {

--- a/pkg/mixer/lint.go
+++ b/pkg/mixer/lint.go
@@ -108,7 +108,7 @@ func lintPrometheusAlertsGuidelines(rule *rulefmt.RuleNode) (errs []error) {
 	}
 
 	if rule.Labels["severity"] != "warning" && rule.Labels["severity"] != "critical" && rule.Labels["severity"] != "info" {
-		errs = append(errs, fmt.Errorf("[alert-severity-rule] Alert '%s' severify must be 'warning', 'critical' or 'info', is currently '%s'", rule.Alert.Value, rule.Labels["severity"]))
+		errs = append(errs, fmt.Errorf("[alert-severity-rule] Alert '%s' severity must be 'warning', 'critical' or 'info', is currently '%s'", rule.Alert.Value, rule.Labels["severity"]))
 	}
 
 	if _, ok := rule.Annotations["description"]; !ok {

--- a/pkg/mixer/lint_test.go
+++ b/pkg/mixer/lint_test.go
@@ -122,7 +122,7 @@ var alertTests = []struct {
 			},
 			'for': '15m',
 		}`,
-		`[alert-severity-rule] Alert 'TestAlert' severify must be 'warning', 'critical' or 'info', is currently 'disaster'`,
+		`[alert-severity-rule] Alert 'TestAlert' severity must be 'warning', 'critical' or 'info', is currently 'disaster'`,
 	},
 	{
 		`{
@@ -136,7 +136,7 @@ var alertTests = []struct {
 			},
 			'for': '15m',
 		}`,
-		`[alert-severity-rule] Alert 'TestAlert' severify must be 'warning', 'critical' or 'info', is currently ''`,
+		`[alert-severity-rule] Alert 'TestAlert' severity must be 'warning', 'critical' or 'info', is currently ''`,
 	},
 	// summary
 	{

--- a/pkg/mixer/lint_test.go
+++ b/pkg/mixer/lint_test.go
@@ -15,6 +15,7 @@
 package mixer
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -38,6 +39,216 @@ func TestLintPrometheusAlerts(t *testing.T) {
 	for err := range errs {
 		t.Errorf("linting wrote unexpected output: %v", err)
 	}
+}
+
+var alertTests = []struct {
+	alert           string // input
+	expectedLintErr string // expected lint error
+}{
+	// valid alert
+	{
+		`{
+			alert: 'TestAlert',
+			expr: 'up == 0',
+			labels: {
+				severity: 'warning',
+			},
+			annotations: {
+				description: '{{ $labels.instance }} has been unready for more than 15 minutes.',
+				summary: 'Instance is not ready.',
+			},
+			'for': '15m',
+		}`,
+		``,
+	},
+	// alertnames
+	{
+		`{
+			alert: 'testAlert',
+			expr: 'up == 0',
+			labels: {
+				severity: 'warning',
+			},
+			annotations: {
+				description: '{{ $labels.instance }} has been unready for more than 15 minutes.',
+				summary: 'Instance is not ready.',
+			},
+			'for': '15m',
+		}`,
+		`[alert-name-camelcase] Alert 'testAlert' name is not in camel case`,
+	},
+	{
+		`{
+			alert: 'test_Alert',
+			expr: 'up == 0',
+			labels: {
+				severity: 'warning',
+			},
+			annotations: {
+				description: '{{ $labels.instance }} has been unready for more than 15 minutes.',
+				summary: 'Instance is not ready.',
+			},
+			'for': '15m',
+		}`,
+		`[alert-name-camelcase] Alert 'test_Alert' name is not in camel case`,
+	},
+	{
+		`{
+			alert: 'test Alert',
+			expr: 'up == 0',
+			labels: {
+				severity: 'warning',
+			},
+			annotations: {
+				description: '{{ $labels.instance }} has been unready for more than 15 minutes.',
+				summary: 'Instance is not ready.',
+			},
+			'for': '15m',
+		}`,
+		`[alert-name-camelcase] Alert 'test Alert' name is not in camel case`,
+	},
+
+	// severity
+	{
+		`{
+			alert: 'TestAlert',
+			expr: 'up == 0',
+			labels: {
+				severity: 'disaster',
+			},
+			annotations: {
+				description: '{{ $labels.instance }} has been unready for more than 15 minutes.',
+				summary: 'Instance is not ready.',
+			},
+			'for': '15m',
+		}`,
+		`[alert-severity-rule] Alert 'TestAlert' severify must be 'warning', 'critical' or 'info', is currently 'disaster'`,
+	},
+	{
+		`{
+			alert: 'TestAlert',
+			expr: 'up == 0',
+			labels: {
+			},
+			annotations: {
+				description: '{{ $labels.instance }} has been unready for more than 15 minutes.',
+				summary: 'Instance is not ready.',
+			},
+			'for': '15m',
+		}`,
+		`[alert-severity-rule] Alert 'TestAlert' severify must be 'warning', 'critical' or 'info', is currently ''`,
+	},
+	// summary
+	{
+		`{
+			alert: 'TestAlert',
+			expr: 'up == 0',
+			labels: {
+				severity: 'warning',
+			},
+			annotations: {
+				summary: 'Instance is not ready.',
+			},
+			'for': '15m',
+		}`,
+		`[alert-description-missing-rule] Alert 'TestAlert' must have annotation 'description'`,
+	},
+	{
+		`{
+			alert: 'TestAlert',
+			expr: 'up == 0',
+			labels: {
+				severity: 'warning',
+			},
+			annotations: {
+				summary: 'Instance {{ $labels.instance}} is not ready.',
+				description: '{{ $labels.instance }} has been unready for more than 15 minutes.',
+			},
+			'for': '15m',
+		}`,
+		`[alert-summary-templating] Alert TestAlert annotation 'summary' must not use templates`,
+	},
+	{
+		`{
+			alert: 'TestAlert',
+			expr: 'up == 0',
+			labels: {
+				severity: 'warning',
+			},
+			annotations: {
+				summary: 'Instance is not ready',
+				description: '{{ $labels.instance }} has been unready for more than 15 minutes.',
+			},
+			'for': '15m',
+		}`,
+		`[alert-summary-style] Alert TestAlert annotation 'summary' must start with capital letter and end with period, is currently 'Instance is not ready'`,
+	},
+	// description
+	{
+		`{
+			alert: 'TestAlert',
+			expr: 'up == 0',
+			labels: {
+				severity: 'warning',
+			},
+			annotations: {
+				summary: 'Instance is not ready.',
+				description: '{{ $labels.instance }} has been unready for more than 15 minutes.',
+			},
+			'for': '15m',
+		}`,
+		`[alert-summary-missing-rule] Alert 'TestAlert' must have annotation 'summary'`,
+	},
+	{
+		`{
+			alert: 'TestAlert',
+			expr: 'up == 0',
+			labels: {
+				severity: 'warning',
+			},
+			annotations: {
+				summary: 'Instance is not ready.',
+				description: 'Instance has been unready for more than 15 minutes.',
+			},
+			'for': '15m',
+		}`,
+		`[alert-description-templating] Alert TestAlert annotation 'description' must use templates, is currently 'Instance has been unready for more than 15 minutes.'`,
+	},
+}
+
+func TestLintPrometheusAlertsGuidelines(t *testing.T) {
+
+	for _, alertTest := range alertTests {
+
+		alerts := fmt.Sprintf(`
+		{
+			_config+:: {},
+			prometheusAlerts+: {
+				groups+: [
+				  {
+					name: 'test',
+					rules: [
+					  %s,
+					],
+				  },
+				],
+			},
+		}
+		`, alertTest.alert)
+
+		filename, delete := writeTempFile(t, "alerts.jsonnet", alerts)
+		defer delete()
+
+		vm := jsonnet.MakeVM()
+		errs := make(chan error)
+		go lintPrometheus(filename, vm, errs)
+		for err := range errs {
+			if err.Error() != alertTest.expectedLintErr {
+				t.Errorf("linting wrote unexpected output, expected '%s', got: %v", alertTest.expectedLintErr, err)
+			}
+		}
+	}
+
 }
 
 func TestLintPrometheusRules(t *testing.T) {

--- a/pkg/mixer/lint_test.go
+++ b/pkg/mixer/lint_test.go
@@ -67,8 +67,8 @@ func writeTempFile(t *testing.T, pattern string, contents string) (filename stri
 		t.Errorf("failed to create temp file: %v", err)
 	}
 
-	if _, err := f.WriteString(rules); err != nil {
-		t.Errorf("failed to write rules.jsonnet to disk: %v", err)
+	if _, err := f.WriteString(contents); err != nil {
+		t.Errorf("failed to write temp file to disk: %v", err)
 	}
 
 	if err := f.Close(); err != nil {

--- a/pkg/mixer/new.go
+++ b/pkg/mixer/new.go
@@ -80,9 +80,10 @@ const alerts = `{
               severity: 'warning',
             },
             annotations: {
-              message: 'Overcommited CPU resource requests on Pods, cannot tolerate node failure.',
+              description: '{{ $labels.node }} has been unready for more than 15 minutes.',
+              summary: 'Node is not ready.',
             },
-            'for': '1h',
+            'for': '15m',
           },
         ],
       },


### PR DESCRIPTION
Enforces alerting guidelines for monitoring-mixin https://monitoring.mixins.dev/#guidelines-for-alert-names-labels-and-annotations via `mixtool lint` command.

Also creation of temp file in lint_test.go was broken, fixed as well.