### PR TITLE
Relax alert name regex

### DIFF
--- a/pkg/mixer/lint.go
+++ b/pkg/mixer/lint.go
@@ -95,7 +95,7 @@ func lintPrometheus(filename string, vm *jsonnet.VM, errsOut chan<- error) {
 
 }
 
-var camelCaseRegexp = regexp.MustCompile(`^([A-Z][a-z0-9]+)+$`)
+var camelCaseRegexp = regexp.MustCompile(`^([A-Z]+[a-z0-9]+)+$`)
 var goTemplateRegexp = regexp.MustCompile(`\{\{.+}\}`)
 var sentenceRegexp = regexp.MustCompile(`^[A-Z].+\.$`)
 

--- a/pkg/mixer/lint_test.go
+++ b/pkg/mixer/lint_test.go
@@ -61,6 +61,21 @@ var alertTests = []struct {
 		}`,
 		``,
 	},
+	{
+		`{
+			alert: 'SNMPDown',
+			expr: 'up == 0',
+			labels: {
+				severity: 'warning',
+			},
+			annotations: {
+				description: '{{ $labels.instance }} has been unready for more than 15 minutes.',
+				summary: 'SNMP is down.',
+			},
+			'for': '15m',
+		}`,
+		``,
+	},
 	// alertnames
 	{
 		`{


### PR DESCRIPTION
Allow multiple initial caps for acronyms in alert names.

Fixes: https://github.com/monitoring-mixins/mixtool/issues/82

Signed-off-by: SuperQ <superq@gmail.com>