### PR TITLE
Update golangci-lint to latest version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.45.2
+          version: v1.50.1


### PR DESCRIPTION
This fixes the issues with linting discussed in #101 

I *believe* this is an issue with the golang version, or compatible modules. In any case, the latest golangci-lint version sorts things out.