### PR TITLE
Improve error messages

### DIFF
--- a/pkg/mixer/lint.go
+++ b/pkg/mixer/lint.go
@@ -195,19 +195,19 @@ func lintGrafanaDashboards(filename string, vm *jsonnet.VM, errsOut chan<- error
 		config := lint.NewConfigurationFile()
 		configFilename := path.Join(path.Dir(filename), ".lint")
 		if err := config.Load(configFilename); err != nil {
-			errsOut <- err
+			errsOut <- fmt.Errorf("Failed to load the dashboard-linter config file %s: %v", configFilename, err)
 			continue
 		}
 
 		dash, err := lint.NewDashboard(raw)
 		if err != nil {
-			errsOut <- err
+			errsOut <- fmt.Errorf("Failed to parse the dashboard %s: %v", dashboardFilename, err)
 			continue
 		}
 
 		rs, err := rules.Lint([]lint.Dashboard{dash})
 		if err != nil {
-			errsOut <- err
+			errsOut <- fmt.Errorf("Failed to lint the dashboard %s: %v", dashboardFilename, err)
 			continue
 		}
 

--- a/pkg/mixer/lint.go
+++ b/pkg/mixer/lint.go
@@ -195,19 +195,19 @@ func lintGrafanaDashboards(filename string, vm *jsonnet.VM, errsOut chan<- error
 		config := lint.NewConfigurationFile()
 		configFilename := path.Join(path.Dir(filename), ".lint")
 		if err := config.Load(configFilename); err != nil {
-			errsOut <- fmt.Errorf("Failed to load the dashboard-linter config file %s: %v", configFilename, err)
+			errsOut <- fmt.Errorf("failed to load the dashboard-linter config file %s: %v", configFilename, err)
 			continue
 		}
 
 		dash, err := lint.NewDashboard(raw)
 		if err != nil {
-			errsOut <- fmt.Errorf("Failed to parse the dashboard %s: %v", dashboardFilename, err)
+			errsOut <- fmt.Errorf("failed to parse the dashboard %s: %v", dashboardFilename, err)
 			continue
 		}
 
 		rs, err := rules.Lint([]lint.Dashboard{dash})
 		if err != nil {
-			errsOut <- fmt.Errorf("Failed to lint the dashboard %s: %v", dashboardFilename, err)
+			errsOut <- fmt.Errorf("failed to lint the dashboard %s: %v", dashboardFilename, err)
 			continue
 		}
 


### PR DESCRIPTION
This should help to pin down the dashboard that failed to be parsed if there is more than one dashboard in the mixin.

Example:

Before:
```
json: cannot unmarshal string into Go struct field Threshold.panels.fieldConfig.Defaults.thresholds.steps.value of type float64
```

After:
```
failed to parse the dashboard pub-sub.json: json: cannot unmarshal string into Go struct field Threshold.panels.fieldConfig.Defaults.thresholds.steps.value of type float64
2024/12/11 17:41:12 failed to lint the file ./integrations/gcp/mixin.libsonnet: 1 lint errors found
```